### PR TITLE
Update gatsby-source-filesystem

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepublishOnly": "yarn run build"
   },
   "dependencies": {
-    "gatsby-source-filesystem": "^2.0.1-rc.6",
+    "gatsby-source-filesystem": "^2.0.12",
     "node-fetch": "^2.2.0",
     "query-string": "^6.1.0"
   },


### PR DESCRIPTION
`gatsby-source-filesystem` is pretty heavilly used. I'd suggest making this a peer dependency instead of a direct dependency. 

The reason for the upgrade here is because the older version of `gatsby-source-filesystem` had a bug that would result in the wrong file extension for some urls.

Example: `https://scontent-sea1-1.cdninstagram.com/vp/478a...532233_n.jpg?_nc_ht=scontent-sea1-1.cdninstagram.com`
This url has some query params the end in `.com` which would result in the image extension being `.com` when downloaded locally. Then the ImageSharp plugin wouldn't be able to load the image.