### PR TITLE
Set the parentNodeId so File nodes aren't garbage collected on restarts

### DIFF
--- a/src/onCreateNode.js
+++ b/src/onCreateNode.js
@@ -7,6 +7,7 @@ async function onCreateNode({ node, cache, actions, store, createNodeId }) {
     try {
       fileNode = await createRemoteFileNode({
         url: node.images.standard_resolution.url,
+        parentNodeId: node.id,
         store,
         cache,
         createNode,


### PR DESCRIPTION
https://github.com/gatsbyjs/gatsby/pull/11795