### PR TITLE
Add Plugin Options section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,12 @@ Query data like this:
     }
  ```
  You can also get videos, comments, likes, tags etc. Read [Instagram API Docs](https://www.instagram.com/developer/endpoints/users/) for example response.
+
+ ## Plugin Options
+
+Option | Type | Description
+-- | -- | --
+access_token | string | Your access token
+max_id | string (optional) | Option to return media earlier than, but not including, this max_id
+min_id | string (optional) | Option to return media later than, and including, this min_id
+


### PR DESCRIPTION
The Instagram API allows a max_id and min_id parameter. Helpful for any users that wish to only grab, say, the last 10 items from their feed.

This PR adds a Plugins Option section to the README that details these id options.
These options seem to be passed into the API request automatically if they exist.