### PR TITLE
Implements Instagram's Basic Display API, plugin working again closes #12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 yarn.lock
 node_modules
 dist
+.idea

--- a/src/onCreateNode.js
+++ b/src/onCreateNode.js
@@ -6,7 +6,7 @@ async function onCreateNode({ node, cache, actions, store, createNodeId }) {
   if (node.internal.type === "InstagramContent") {
     try {
       fileNode = await createRemoteFileNode({
-        url: node.images.standard_resolution.url,
+        url: node.media_url,
         parentNodeId: node.id,
         store,
         cache,

--- a/src/sourceNodes.js
+++ b/src/sourceNodes.js
@@ -12,7 +12,7 @@ async function sourceNodes({
 
   delete configOptions.plugins
   const apiOptions = queryString.stringify(configOptions)
-  const apiUrl = `https://api.instagram.com/v1/users/self/media/recent/?${apiOptions}&count=30`
+  const apiUrl = `https://graph.instagram.com/me/media?fields=id,media_url,caption&${apiOptions}&limit=30`
 
   // Helper Function to fetch and parse data to JSON
   const fetchAndParse = async (api) => {
@@ -24,13 +24,14 @@ async function sourceNodes({
   // Helper to recursiveley get data from Instagram api
   const getData = async (url, data = []) => {
     let response = await fetchAndParse(url);
-    if (response.meta.code !== 200) {
-      console.error('\nINSTAGRAM API ERROR: ', response.meta.error_message);
+    if(response.error !== undefined){
+      console.error('\nINSTAGRAM API ERROR: ', response.error.message);
       return data
     }
 
     data = data.concat(response.data)
-    let next_url = response.pagination.next_url;
+    let next_url = response.paging.next;
+
 
     if (next_url !== undefined) {
       return getData(next_url, data)


### PR DESCRIPTION
Got this working again using the Instagram Basic Display API.

Instructions on getting a token:
https://developers.facebook.com/docs/instagram-basic-display-api

There is a change to the static query. Instead of 
`{images {
      standard_resolution{
         url
 }}
` it's just `{media_url}` and for captions, instead of 
`{ caption { 
     text
    }
}` it's just `{caption}`

Please feel free to make any changes you wish.

Thanks.