### PR TITLE
Additional fields + fix in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format": "prettier --write src/**/*.js",
     "clean": "rm -rf dist",
     "prepublishOnly": "yarn run build",
-    "install": "yarn run build"
+    "prepare": "yarn run build"
   },
   "dependencies": {
     "gatsby-source-filesystem": "^2.0.12",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "watch": "babel --watch src --out-dir dist --ignore **/__tests__",
     "format": "prettier --write src/**/*.js",
     "clean": "rm -rf dist",
-    "prepublishOnly": "yarn run build"
+    "prepublishOnly": "yarn run build",
+    "install": "yarn run build"
   },
   "dependencies": {
     "gatsby-source-filesystem": "^2.0.12",

--- a/src/sourceNodes.js
+++ b/src/sourceNodes.js
@@ -7,7 +7,7 @@ async function sourceNodes({ actions, createNodeId }, configOptions) {
 
   delete configOptions.plugins
   const apiOptions = queryString.stringify(configOptions)
-  const apiUrl = `https://graph.instagram.com/me/media?fields=id,media_url,media_type,permalink,caption&${apiOptions}&limit=30`
+  const apiUrl = `https://graph.instagram.com/me/media?fields=id,ig_id,media_url,media_type,permalink,timestamp,caption&${apiOptions}&limit=30`
 
   // Helper Function to fetch and parse data to JSON
   const fetchAndParse = async (api) => {
@@ -39,7 +39,7 @@ async function sourceNodes({ actions, createNodeId }, configOptions) {
   const createNodes = async (API) => {
     await getData(API).then((res) => {
       res.forEach((item) => {
-        if (item.id !== undefined && item.media_type === "IMAGE") {
+        if (item.id !== undefined && ["IMAGE", "CAROUSEL_ALBUM"].includes(item.media_type)) {
           const nodeData = processPhoto(item)
           createNode(nodeData)
         }

--- a/src/sourceNodes.js
+++ b/src/sourceNodes.js
@@ -7,7 +7,7 @@ async function sourceNodes({ actions, createNodeId }, configOptions) {
 
   delete configOptions.plugins
   const apiOptions = queryString.stringify(configOptions)
-  const apiUrl = `https://graph.instagram.com/me/media?fields=id,ig_id,media_url,media_type,permalink,timestamp,caption&${apiOptions}&limit=30`
+  const apiUrl = `https://graph.instagram.com/me/media?fields=id,media_url,media_type,permalink,timestamp,caption&${apiOptions}&limit=30`
 
   // Helper Function to fetch and parse data to JSON
   const fetchAndParse = async (api) => {
@@ -58,6 +58,7 @@ async function sourceNodes({ actions, createNodeId }, configOptions) {
 
     const nodeData = Object.assign({}, photo, {
       id: nodeId,
+      media_id: photo.id,
       parent: null,
       children: [],
       internal: {


### PR DESCRIPTION
- added timestamp field in instagram graph api url
- store original post id as media_id, because currently it is overwritten by node id
- allow CAROUSEL_ALBUM media type to be parsed (it parses first photo from album)
- added "prepare" script in package.json to correctly build the package when adding it using git url (yarn add <git url>)